### PR TITLE
Use same system for storing hjemmel and ytelser as in Kabal-api.

### DIFF
--- a/src/main/kotlin/db/migration/V14__migrate_innstillinger.kt
+++ b/src/main/kotlin/db/migration/V14__migrate_innstillinger.kt
@@ -1,0 +1,49 @@
+package db.migration
+
+import no.nav.klage.kodeverk.hjemmel.Hjemmel
+import no.nav.klage.kodeverk.ytelse.Ytelse
+import org.flywaydb.core.api.migration.BaseJavaMigration
+import org.flywaydb.core.api.migration.Context
+
+class V14__migrate_innstillinger : BaseJavaMigration() {
+    override fun migrate(context: Context) {
+        val preparedHjemmelStatement = context.connection.prepareStatement(
+            """
+                INSERT INTO innstillinger.innstillinger_hjemmel (id, innstillinger_saksbehandlerident)
+                    VALUES(?, ?)
+            """.trimIndent()
+        )
+        val preparedYtelseStatement = context.connection.prepareStatement(
+            """
+                INSERT INTO innstillinger.innstillinger_ytelse (id, innstillinger_saksbehandlerident)
+                    VALUES(?, ?)
+            """.trimIndent()
+        )
+        //TODO: Lag indeks i nye tabeller
+        context.connection.createStatement().use { select ->
+            select.executeQuery(
+                """
+                    select innstillinger.saksbehandlerident, innstillinger.hjemler, innstillinger.ytelser
+                    from innstillinger.innstillinger
+                    """
+            )
+                .use { rows ->
+                    while (rows.next()) {
+                        val saksbehandlerIdent = rows.getString(1)
+                        val hjemler = rows.getString(2).split(",").filterNot { it.isBlank() }.map { Hjemmel.of(it) }
+                        val ytelser = rows.getString(3).split(",").filterNot { it.isBlank() }.map { Ytelse.of(it) }
+                        hjemler.forEach { hjemmel ->
+                            preparedHjemmelStatement.setString(1, saksbehandlerIdent)
+                            preparedHjemmelStatement.setString(2, hjemmel.id)
+                            preparedHjemmelStatement.executeUpdate()
+                        }
+                        ytelser.forEach { ytelse ->
+                            preparedYtelseStatement.setString(1, saksbehandlerIdent)
+                            preparedYtelseStatement.setString(2, ytelse.id)
+                            preparedYtelseStatement.executeUpdate()
+                        }
+                    }
+                }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/klage/oppgave/api/mapper/SaksbehandlerMapper.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/mapper/SaksbehandlerMapper.kt
@@ -29,15 +29,14 @@ class SaksbehandlerMapper(
 
     fun mapToView(saksbehandlerInnstillinger: SaksbehandlerInnstillinger) =
         InnstillingerView(
-            hjemler = saksbehandlerInnstillinger.hjemler.map { it.id },
-            ytelser = saksbehandlerInnstillinger.ytelser.sortedBy { it.navn }.map { it.id },
-            typer = emptyList()
+            hjemler = saksbehandlerInnstillinger.hjemler.map { it.id }.toSet(),
+            ytelser = saksbehandlerInnstillinger.ytelser.sortedBy { it.navn }.map { it.id }.toSet(),
         )
 
     fun mapToDomain(innstillingerView: InnstillingerView) =
         SaksbehandlerInnstillinger(
-            hjemler = innstillingerView.hjemler.map { Hjemmel.of(it) },
-            ytelser = innstillingerView.ytelser.map { Ytelse.of(it) },
+            hjemler = innstillingerView.hjemler.map { Hjemmel.of(it) }.toSet(),
+            ytelser = innstillingerView.ytelser.map { Ytelse.of(it) }.toSet(),
             //Placeholder, ignored later
             anonymous = false
         )

--- a/src/main/kotlin/no/nav/klage/oppgave/api/view/SaksbehandlerBrukerdata.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/view/SaksbehandlerBrukerdata.kt
@@ -10,10 +10,8 @@ data class SaksbehandlerView(
 )
 
 data class InnstillingerView(
-    val hjemler: List<String>,
-    val ytelser: List<String>,
-    //not in use anymore
-    val typer: List<String>
+    val hjemler: Set<String>,
+    val ytelser: Set<String>,
 )
 
 data class EnhetView(

--- a/src/main/kotlin/no/nav/klage/oppgave/domain/saksbehandler/Saksbehandler.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/domain/saksbehandler/Saksbehandler.kt
@@ -10,12 +10,12 @@ data class SaksbehandlerInfo(
     val enheter: EnheterMedLovligeYtelser,
     val ansattEnhet: EnhetMedLovligeYtelser,
     val saksbehandlerInnstillinger: SaksbehandlerInnstillinger,
-    val tildelteYtelser: List<Ytelse>,
+    val tildelteYtelser: Set<Ytelse>,
 )
 
 data class SaksbehandlerInnstillinger(
-    val hjemler: List<Hjemmel> = emptyList(),
-    val ytelser: List<Ytelse> = emptyList(),
+    val hjemler: Set<Hjemmel> = mutableSetOf(),
+    val ytelser: Set<Ytelse> = mutableSetOf(),
     val shortName: String? = null,
     val longName: String? = null,
     val jobTitle: String? = null,

--- a/src/main/kotlin/no/nav/klage/oppgave/domain/saksbehandler/entities/Innstillinger.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/domain/saksbehandler/entities/Innstillinger.kt
@@ -1,10 +1,8 @@
 package no.nav.klage.oppgave.domain.saksbehandler.entities
 
-import jakarta.persistence.Column
-import jakarta.persistence.Entity
-import jakarta.persistence.Id
-import jakarta.persistence.Table
+import jakarta.persistence.*
 import no.nav.klage.kodeverk.hjemmel.Hjemmel
+import no.nav.klage.kodeverk.hjemmel.HjemmelConverter
 import no.nav.klage.kodeverk.ytelse.Ytelse
 import no.nav.klage.oppgave.domain.saksbehandler.SaksbehandlerInnstillinger
 import no.nav.klage.oppgave.util.getLogger
@@ -18,10 +16,24 @@ class Innstillinger(
     @Id
     @Column(name = "saksbehandlerident")
     val saksbehandlerident: String,
-    @Column(name = "hjemler")
-    var hjemler: String = "",
-    @Column(name = "ytelser")
-    var ytelser: String = "",
+    @ElementCollection(targetClass = Hjemmel::class, fetch = FetchType.LAZY)
+    @CollectionTable(
+        name = "innstillinger_hjemmel",
+        schema = "innstillinger",
+        joinColumns = [JoinColumn(name = "innstillinger_saksbehandlerident", referencedColumnName = "saksbehandlerident", nullable = false)]
+    )
+    @Convert(converter = HjemmelConverter::class)
+    @Column(name = "id")
+    var hjemler: Set<Hjemmel> = emptySet(),
+    @ElementCollection(targetClass = Ytelse::class, fetch = FetchType.LAZY)
+    @CollectionTable(
+        name = "innstillinger_ytelse",
+        schema = "innstillinger",
+        joinColumns = [JoinColumn(name = "innstillinger_saksbehandlerident", referencedColumnName = "saksbehandlerident", nullable = false)]
+    )
+    @Convert(converter = YtelseConverter::class)
+    @Column(name = "id")
+    var ytelser: Set<Ytelse> = emptySet(),
     @Column(name = "short_name")
     var shortName: String? = null,
     @Column(name = "long_name")
@@ -43,8 +55,8 @@ class Innstillinger(
 
     fun toSaksbehandlerInnstillinger(): SaksbehandlerInnstillinger {
         return SaksbehandlerInnstillinger(
-            hjemler = hjemler.split(SEPARATOR).filterNot { it.isBlank() }.map { Hjemmel.of(it) },
-            ytelser = ytelser.split(SEPARATOR).filterNot { it.isBlank() }.map { Ytelse.of(it) },
+            hjemler = hjemler,
+            ytelser = ytelser,
             shortName = shortName,
             longName = longName,
             jobTitle = jobTitle,
@@ -68,7 +80,6 @@ class Innstillinger(
     }
 
     override fun toString(): String {
-        return "Innstillinger(saksbehandlerident='$saksbehandlerident', hjemler='$hjemler', ytelser='$ytelser', shortName='$shortName', longName='$longName', jobTitle='$jobTitle', modified=$modified)"
+        return "Innstillinger(saksbehandlerident='$saksbehandlerident', hjemler=$hjemler, ytelser=$ytelser, shortName=$shortName, longName=$longName, jobTitle=$jobTitle, modified=$modified, anonymous=$anonymous)"
     }
-
 }

--- a/src/main/kotlin/no/nav/klage/oppgave/service/InnstillingerService.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/service/InnstillingerService.kt
@@ -36,16 +36,15 @@ class InnstillingerService(
     fun storeInnstillingerButKeepSignature(
         navIdent: String,
         newSaksbehandlerInnstillinger: SaksbehandlerInnstillinger,
-        assignedYtelseList: List<Ytelse>,
+        assignedYtelseSet: Set<Ytelse>,
     ): SaksbehandlerInnstillinger {
         val oldInnstillinger = innstillingerRepository.findBySaksbehandlerident(navIdent)
 
         return innstillingerRepository.save(
             Innstillinger(
                 saksbehandlerident = navIdent,
-                hjemler = newSaksbehandlerInnstillinger.hjemler.joinToString(SEPARATOR) { it.id },
-                ytelser = newSaksbehandlerInnstillinger.ytelser.filter { it in assignedYtelseList }
-                    .joinToString(SEPARATOR) { it.id },
+                hjemler = newSaksbehandlerInnstillinger.hjemler,
+                ytelser = newSaksbehandlerInnstillinger.ytelser.filter { it in assignedYtelseSet }.toSet(),
                 shortName = oldInnstillinger?.shortName,
                 longName = oldInnstillinger?.longName,
                 jobTitle = oldInnstillinger?.jobTitle,
@@ -58,22 +57,20 @@ class InnstillingerService(
     fun updateYtelseAndHjemmelInnstillinger(
         navIdent: String,
         inputYtelseSet: Set<Ytelse>,
-        assignedYtelseList: List<Ytelse>,
+        assignedYtelseSet: Set<Ytelse>,
     ) {
-        val filteredYtelseList = inputYtelseSet.filter { it in assignedYtelseList }
+        val filteredYtelseSet = inputYtelseSet.filter { it in assignedYtelseSet }.toSet()
 
         if (!innstillingerRepository.existsById(navIdent)) {
             val hjemmelSet = getUpdatedHjemmelSet(
-                ytelserToAdd = filteredYtelseList.toSet()
+                ytelserToAdd = filteredYtelseSet,
             )
 
             innstillingerRepository.save(
                 Innstillinger(
                     saksbehandlerident = navIdent,
-                    hjemler = hjemmelSet
-                        .joinToString(SEPARATOR) { it.id },
-                    ytelser = filteredYtelseList
-                        .joinToString(SEPARATOR) { it.id },
+                    hjemler = hjemmelSet,
+                    ytelser = filteredYtelseSet,
                     shortName = null,
                     longName = null,
                     jobTitle = null,
@@ -103,10 +100,8 @@ class InnstillingerService(
             )
 
             innstillingerRepository.getReferenceById(navIdent).apply {
-                ytelser = filteredYtelseList
-                    .joinToString(SEPARATOR) { it.id }
+                ytelser = filteredYtelseSet
                 hjemler = hjemmelSet
-                    .joinToString(SEPARATOR) { it.id }
                 modified = LocalDateTime.now()
             }
         }
@@ -216,7 +211,7 @@ class InnstillingerService(
                         innstilling.saksbehandlerident
                     )
                     innstilling.apply {
-                        hjemler = newHjemmelSet.joinToString(SEPARATOR) { it.id }
+                        hjemler = newHjemmelSet
                     }
                 } else {
                     logger.debug("Ingen nye hjemler å lagre for saksbehandler {}", innstilling.saksbehandlerident)

--- a/src/main/kotlin/no/nav/klage/oppgave/service/SaksbehandlerAccessService.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/service/SaksbehandlerAccessService.kt
@@ -116,7 +116,7 @@ class SaksbehandlerAccessService(
             innstillingerService.updateYtelseAndHjemmelInnstillinger(
                 navIdent = accessRight.saksbehandlerIdent,
                 inputYtelseSet = ytelseSet,
-                assignedYtelseList = ytelseSet.toList()
+                assignedYtelseSet = ytelseSet
             )
 
             saksbehandlerAccessList += SaksbehandlerAccessView(
@@ -130,11 +130,11 @@ class SaksbehandlerAccessService(
         return SaksbehandlerAccessResponse(accessRights = saksbehandlerAccessList)
     }
 
-    fun getSaksbehandlerAssignedYtelseList(saksbehandlerIdent: String): List<Ytelse> {
+    fun getSaksbehandlerAssignedYtelseSet(saksbehandlerIdent: String): Set<Ytelse> {
         return if (saksbehandlerAccessRepository.existsById(saksbehandlerIdent)) {
             val saksbehandlerAccess = saksbehandlerAccessRepository.getReferenceById(saksbehandlerIdent)
-            saksbehandlerAccess.ytelser.toList()
-        } else emptyList()
+            saksbehandlerAccess.ytelser
+        } else mutableSetOf()
     }
 
     fun logAnsattStatusInNom() {

--- a/src/main/kotlin/no/nav/klage/oppgave/service/SaksbehandlerService.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/service/SaksbehandlerService.kt
@@ -32,7 +32,7 @@ class SaksbehandlerService(
 
     fun getDataOmSaksbehandler(navIdent: String): SaksbehandlerInfo {
         val enhetMedYtelserForSaksbehandler = getEnhetMedYtelserForSaksbehandler(navIdent = navIdent)
-        val assignedYtelser = saksbehandlerAccessService.getSaksbehandlerAssignedYtelseList(navIdent)
+        val assignedYtelser = saksbehandlerAccessService.getSaksbehandlerAssignedYtelseSet(navIdent)
 
         val saksbehandlerInnstillinger = innstillingerService.findSaksbehandlerInnstillinger(
             ident = navIdent,
@@ -202,7 +202,7 @@ class SaksbehandlerService(
         return innstillingerService.storeInnstillingerButKeepSignature(
             navIdent = navIdent,
             newSaksbehandlerInnstillinger = newSaksbehandlerInnstillinger,
-            assignedYtelseList = saksbehandlerAccessService.getSaksbehandlerAssignedYtelseList(navIdent)
+            assignedYtelseSet = saksbehandlerAccessService.getSaksbehandlerAssignedYtelseSet(navIdent)
         )
     }
 }

--- a/src/main/resources/db/migration/V13__Refactor_ytelser_and_hjemler.sql
+++ b/src/main/resources/db/migration/V13__Refactor_ytelser_and_hjemler.sql
@@ -1,0 +1,28 @@
+ALTER TABLE innstillinger.innstillinger
+    ALTER COLUMN hjemler drop not null;
+
+ALTER TABLE innstillinger.innstillinger
+    ALTER COLUMN ytelser drop not null;
+
+CREATE TABLE innstillinger.innstillinger_hjemmel
+(
+    id        TEXT NOT NULL,
+    innstillinger_saksbehandlerident TEXT NOT NULL,
+    PRIMARY KEY (id, innstillinger_saksbehandlerident),
+    CONSTRAINT fk_hjemmel_innstillinger
+        FOREIGN KEY (innstillinger_saksbehandlerident)
+            REFERENCES innstillinger.innstillinger (saksbehandlerident)
+);
+
+CREATE TABLE innstillinger.innstillinger_ytelse
+(
+    id        TEXT NOT NULL,
+    innstillinger_saksbehandlerident TEXT NOT NULL,
+    PRIMARY KEY (id, innstillinger_saksbehandlerident),
+    CONSTRAINT fk_ytelse_innstillinger
+        FOREIGN KEY (innstillinger_saksbehandlerident)
+            REFERENCES innstillinger.innstillinger (saksbehandlerident)
+);
+
+CREATE INDEX innstilling_hjemmel_saksbehandleridentx ON innstillinger.innstillinger_hjemmel (innstillinger_saksbehandlerident);
+CREATE INDEX innstilling_ytelse_saksbehandleridentx ON innstillinger.innstillinger_ytelse (innstillinger_saksbehandlerident);

--- a/src/test/kotlin/no/nav/klage/oppgave/repositories/InnstillingerRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/klage/oppgave/repositories/InnstillingerRepositoryTest.kt
@@ -1,6 +1,8 @@
 package no.nav.klage.oppgave.repositories
 
 
+import no.nav.klage.kodeverk.hjemmel.Hjemmel
+import no.nav.klage.kodeverk.ytelse.Ytelse
 import no.nav.klage.oppgave.db.TestPostgresqlContainer
 import no.nav.klage.oppgave.domain.saksbehandler.entities.Innstillinger
 import org.assertj.core.api.Assertions.assertThat
@@ -36,8 +38,8 @@ class InnstillingerRepositoryTest {
         val navIdent = "AB12345"
         val innstillinger = Innstillinger(
             saksbehandlerident = navIdent,
-            hjemler = "1,12",
-            ytelser = "3,4",
+            hjemler = setOf(Hjemmel.of("FVL_16"), Hjemmel.of("FS_TILL_ST_15_2")),
+            ytelser = setOf(Ytelse.of("3"), Ytelse.of("4")),
             shortName = "shortName",
             longName = "longName",
             jobTitle = "myTitle",

--- a/src/test/kotlin/no/nav/klage/oppgave/service/InnstillingerServiceTest.kt
+++ b/src/test/kotlin/no/nav/klage/oppgave/service/InnstillingerServiceTest.kt
@@ -35,8 +35,8 @@ class InnstillingerServiceTest {
     private val jobTitle = "jobTitle"
 
     private val saksbehandlerInnstillingerInput = SaksbehandlerInnstillinger(
-        hjemler = listOf(hjemmel1, hjemmel2),
-        ytelser = listOf(ytelse1, ytelse2),
+        hjemler = setOf(hjemmel1, hjemmel2),
+        ytelser = setOf(ytelse1, ytelse2),
         shortName = null,
         longName = null,
         jobTitle = null,
@@ -60,7 +60,7 @@ class InnstillingerServiceTest {
         every { innstillingerRepository.findBySaksbehandlerident(ident1) }.returns(
             Innstillinger(
                 saksbehandlerident = ident1,
-                ytelser = "1",
+                ytelser = setOf(Ytelse.of("1")),
                 anonymous = false,
             )
         )
@@ -83,7 +83,7 @@ class InnstillingerServiceTest {
                 /* actual = */ innstillingerService.storeInnstillingerButKeepSignature(
                     navIdent = ident1,
                     newSaksbehandlerInnstillinger = saksbehandlerInnstillingerInput,
-                    assignedYtelseList = listOf(ytelse1, ytelse2)
+                    assignedYtelseSet = setOf(ytelse1, ytelse2)
                 )
             )
         }
@@ -93,12 +93,12 @@ class InnstillingerServiceTest {
             every { innstillingerRepository.findBySaksbehandlerident(ident1) }.returns(null)
 
             assertEquals(
-                /* expected = */ listOf(ytelse1),
+                /* expected = */ listOf(ytelse1).map { it.id },
                 /* actual = */ innstillingerService.storeInnstillingerButKeepSignature(
                     navIdent = ident1,
                     newSaksbehandlerInnstillinger = saksbehandlerInnstillingerInput,
-                    assignedYtelseList = listOf(ytelse1)
-                ).ytelser
+                    assignedYtelseSet = setOf(ytelse1)
+                ).ytelser.map { it.id }
             )
         }
 
@@ -107,8 +107,8 @@ class InnstillingerServiceTest {
 
             val oldInnstillinger = Innstillinger(
                 saksbehandlerident = ident1,
-                hjemler = listOf(hjemmel1, hjemmel2).joinToString(SEPARATOR) { it.id },
-                ytelser = listOf(ytelse1, ytelse2).joinToString(SEPARATOR) { it.id },
+                hjemler = setOf(hjemmel1, hjemmel2),
+                ytelser = setOf(ytelse1, ytelse2),
                 shortName = shortName,
                 longName = longName,
                 jobTitle = jobTitle,
@@ -125,7 +125,7 @@ class InnstillingerServiceTest {
                 /* actual = */ innstillingerService.storeInnstillingerButKeepSignature(
                     navIdent = ident1,
                     newSaksbehandlerInnstillinger = saksbehandlerInnstillingerInput,
-                    assignedYtelseList = listOf(ytelse1, ytelse2)
+                    assignedYtelseSet = setOf(ytelse1, ytelse2)
                 ).shortName
             )
 
@@ -134,7 +134,7 @@ class InnstillingerServiceTest {
                 /* actual = */ innstillingerService.storeInnstillingerButKeepSignature(
                     navIdent = ident1,
                     newSaksbehandlerInnstillinger = saksbehandlerInnstillingerInput,
-                    assignedYtelseList = listOf(ytelse1, ytelse2)
+                    assignedYtelseSet = setOf(ytelse1, ytelse2)
                 ).longName
             )
 
@@ -143,7 +143,7 @@ class InnstillingerServiceTest {
                 /* actual = */ innstillingerService.storeInnstillingerButKeepSignature(
                     navIdent = ident1,
                     newSaksbehandlerInnstillinger = saksbehandlerInnstillingerInput,
-                    assignedYtelseList = listOf(ytelse1, ytelse2)
+                    assignedYtelseSet = setOf(ytelse1, ytelse2)
                 ).jobTitle
             )
 
@@ -152,7 +152,7 @@ class InnstillingerServiceTest {
                 /* actual = */ innstillingerService.storeInnstillingerButKeepSignature(
                     navIdent = ident1,
                     newSaksbehandlerInnstillinger = saksbehandlerInnstillingerInput,
-                    assignedYtelseList = listOf(ytelse1, ytelse2)
+                    assignedYtelseSet = setOf(ytelse1, ytelse2)
                 ).anonymous
             )
         }
@@ -167,15 +167,15 @@ class InnstillingerServiceTest {
             innstillingerService.updateYtelseAndHjemmelInnstillinger(
                 navIdent = ident1,
                 inputYtelseSet = setOf(ytelse1, ytelse2),
-                assignedYtelseList = listOf(ytelse1),
+                assignedYtelseSet = setOf(ytelse1),
             )
 
             verify {
                 innstillingerRepository.save(
                     Innstillinger(
                         saksbehandlerident = ident1,
-                        hjemler = ytelseToHjemler[ytelse1]!!.joinToString(SEPARATOR) { it.id },
-                        ytelser = listOf(ytelse1).joinToString(SEPARATOR) { it.id },
+                        hjemler = ytelseToHjemler[ytelse1]!!.toSet(),
+                        ytelser = setOf(ytelse1),
                         shortName = null,
                         longName = null,
                         jobTitle = null,
@@ -189,15 +189,15 @@ class InnstillingerServiceTest {
         @Test
         fun `existing Innstillinger, saves all hjemler from new ytelse, keeps existing ytelse and hjemler, removes existing hjemler and ytelser no longer legal`() {
             val existingYtelse2Hjemler = ytelseToHjemler[ytelse2]!!.subList(0, 3)
-            val extraExistingHjemler = listOf(ytelseToHjemler[ytelse3]!![0])
+            val extraExistingHjemler = setOf(ytelseToHjemler[ytelse3]!![0])
 
             val existingHjemler = existingYtelse2Hjemler + extraExistingHjemler
 
             val mockInnstillinger = spyk(
                 Innstillinger(
                     saksbehandlerident = ident1,
-                    hjemler = existingHjemler.joinToString(SEPARATOR) { it.id },
-                    ytelser = listOf(ytelse2, ytelse3).joinToString(SEPARATOR) { it.id },
+                    hjemler = existingHjemler.toSet(),
+                    ytelser = setOf(ytelse2, ytelse3),
                     shortName = null,
                     longName = null,
                     jobTitle = null,
@@ -211,8 +211,8 @@ class InnstillingerServiceTest {
             every { mockInnstillinger.hjemler = any() } returnsArgument 0
             every { mockInnstillinger.modified = now } returnsArgument 0
 
-            every { saksbehandlerAccessService.getSaksbehandlerAssignedYtelseList(ident1) }.returns(
-                listOf(
+            every { saksbehandlerAccessService.getSaksbehandlerAssignedYtelseSet(ident1) }.returns(
+                setOf(
                     ytelse1,
                     ytelse2,
                 )
@@ -228,18 +228,17 @@ class InnstillingerServiceTest {
             innstillingerService.updateYtelseAndHjemmelInnstillinger(
                 navIdent = ident1,
                 inputYtelseSet = setOf(ytelse1, ytelse2),
-                assignedYtelseList = listOf(ytelse1, ytelse2),
+                assignedYtelseSet = setOf(ytelse1, ytelse2),
 
                 )
 
             verify {
-                mockInnstillinger setProperty "ytelser" value listOf(
+                mockInnstillinger setProperty "ytelser" value setOf(
                     ytelse1,
                     ytelse2,
-                ).joinToString(SEPARATOR) { it.id }
+                )
 
                 mockInnstillinger setProperty "hjemler" value (ytelseToHjemler[ytelse1]!! + existingYtelse2Hjemler).toSet()
-                    .joinToString(SEPARATOR) { it.id }
             }
         }
     }
@@ -249,8 +248,8 @@ class InnstillingerServiceTest {
         val mockInnstillinger1 = spyk(
             Innstillinger(
                 saksbehandlerident = ident1,
-                hjemler = listOf(hjemmel1).joinToString(SEPARATOR) { it.id },
-                ytelser = listOf(ytelse2, ytelse3).joinToString(SEPARATOR) { it.id },
+                hjemler = setOf(hjemmel1),
+                ytelser = setOf(ytelse2, ytelse3),
                 shortName = null,
                 longName = null,
                 jobTitle = null,
@@ -263,8 +262,8 @@ class InnstillingerServiceTest {
         val mockInnstillinger2 = spyk(
             Innstillinger(
                 saksbehandlerident = ident1,
-                hjemler = listOf(hjemmel2).joinToString(SEPARATOR) { it.id },
-                ytelser = listOf(ytelse3).joinToString(SEPARATOR) { it.id },
+                hjemler = setOf(hjemmel2),
+                ytelser = setOf(ytelse3),
                 shortName = null,
                 longName = null,
                 jobTitle = null,
@@ -285,13 +284,11 @@ class InnstillingerServiceTest {
 
         verify {
             mockInnstillinger1 setProperty "hjemler" value setOf(hjemmel1, hjemmel3, hjemmel4)
-                .joinToString(SEPARATOR) { it.id }
         }
 
         //mockInnstillinger2 does not have ytelse in input, skipped in update.
         verify (exactly = 0) {
             mockInnstillinger2 setProperty "hjemler" value setOf(hjemmel1, hjemmel3, hjemmel4)
-                .joinToString(SEPARATOR) { it.id }
         }
     }
 
@@ -300,8 +297,8 @@ class InnstillingerServiceTest {
         val mockInnstillinger = spyk(
             Innstillinger(
                 saksbehandlerident = ident1,
-                hjemler = listOf(hjemmel1, hjemmel3).joinToString(SEPARATOR) { it.id },
-                ytelser = listOf(ytelse2, ytelse3).joinToString(SEPARATOR) { it.id },
+                hjemler = setOf(hjemmel1, hjemmel3),
+                ytelser = setOf(ytelse2, ytelse3),
                 shortName = null,
                 longName = null,
                 jobTitle = null,
@@ -322,7 +319,6 @@ class InnstillingerServiceTest {
 
         verify(exactly = 0) {
             mockInnstillinger setProperty "hjemler" value setOf(hjemmel1, hjemmel3)
-                .joinToString(SEPARATOR) { it.id }
         }
     }
 }


### PR DESCRIPTION
Use set in stead of list when applicable.
Migrate existing settings.